### PR TITLE
Add padding and in-line flow for lighthouse scores

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -33,24 +33,26 @@ export default function Home() {
         </section>
 
         {/* Lighthouse Scores */}
-        <section className="text-sm text-center sm:text-left font-[family-name:var(--font-geist-mono)] border-thick">
-          <h2 className="font-bold">Lighthouse Scores Desktop:</h2>
-          <ul className="list-inside list-decimal">
-            <li>Performance: 94</li>
-            <li>Accessibility: 100</li>
-            <li>Best Practices: 96</li>
-            <li>SEO: 100</li>
-          </ul>
-        </section>
-        <section className="text-sm text-center sm:text-left font-[family-name:var(--font-geist-mono)] border-thick">
-          <h2 className="font-bold">Lighthouse Scores Mobile:</h2>
-          <ul className="list-inside list-decimal">
-            <li>Performance: 77</li>
-            <li>Accessibility: 100</li>
-            <li>Best Practices: 96</li>
-            <li>SEO: 100</li>
-          </ul>
-        </section>
+        <div className="flex">
+          <section className="text-sm text-center sm:text-left font-[family-name:var(--font-geist-mono)] border-thick m-20">
+            <h2 className="font-bold">Lighthouse Scores Desktop:</h2>
+            <ul className="list-inside list-decimal">
+              <li>Performance: 94</li>
+              <li>Accessibility: 100</li>
+              <li>Best Practices: 96</li>
+              <li>SEO: 100</li>
+            </ul>
+          </section>
+          <section className="text-sm text-center sm:text-left font-[family-name:var(--font-geist-mono)] border-thick m-20">
+            <h2 className="font-bold">Lighthouse Scores Mobile:</h2>
+            <ul className="list-inside list-decimal">
+              <li>Performance: 77</li>
+              <li>Accessibility: 100</li>
+              <li>Best Practices: 96</li>
+              <li>SEO: 100</li>
+            </ul>
+          </section>
+        </div>
       </main>
     </div>
   );


### PR DESCRIPTION
## Summary

- Adds flex box styling and padding for lighthouse scores. Not the greatest, but better than what it was before.

<img width="1511" alt="Screenshot 2024-09-23 at 7 21 51 PM" src="https://github.com/user-attachments/assets/ced6650c-3ab5-4d64-8d2a-b090f5cb882d">
