### PR TITLE
Adds `favicon.png` to PWA

### DIFF
--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -11,7 +11,7 @@ export default function manifest(): MetadataRoute.Manifest {
     theme_color: '#fff',
     icons: [
       {
-        src: '/favicon.ico',
+        src: '/favicon.png',
         sizes: 'any',
         type: 'image/x-icon',
       },


### PR DESCRIPTION
## Summary
- Adds `favicon.png` to app to fix the Lighthouse errors of a missing favicon.