### PR TITLE
feat(reset): Add reset button to results page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,6 +8,12 @@ export default function Home() {
   const [isLoading, setIsLoading] = useState(false);
   const [results, setResults] = useState({pvSize: '0', batterySize: '0', completed: false});
   
+  function handleResetSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setIsLoading(false)
+    setResults({pvSize: '0', batterySize: '0', completed: false})
+  }
+
   function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
     setIsLoading(true);
@@ -112,6 +118,9 @@ export default function Home() {
               <div className="results">
                 <p>PV Size = {results.pvSize}</p>
                 <p>Battery Size = {results.batterySize}</p>
+                <form className="reset-form" onSubmit={handleResetSubmit}>
+                  <button type="submit" className="submit-button">Reset</button>
+                </form>
               </div>
             ) : (
               <form className="simulation-form" onSubmit={handleSubmit}>


### PR DESCRIPTION
## Summary
- Adds a reset button to the results page in `page.tsx`.

## Context
We need an additional task for the user to test. Have a reset button on the results page would be helpful if the user has more than one configuration they'd like to test against.