### PR TITLE
feat(presentation): Introduce presentation link

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -115,7 +115,8 @@ export default function Home() {
               </section>
               <section className="text-sm text-center sm:text-left font-[family-name:var(--font-geist-mono)] border-thick w-full">
               <h2 className="font-bold">🛠️ Demo!:</h2>
-                <div className="video-responsive">
+                <div className="video-responsive" style={{display: "block"}}>
+                  <a style={{display: "block", textAlign: "center", paddingBottom: "20px"}} href="https://docs.google.com/presentation/d/1VRt0P0QH3UsihzLN1k2JoLLMS2xdAgjDxrZaKJftwyM/edit#slide=id.g2f89acebcd9_1_264">🔗 Click here for the presentation slides! 🔗</a>
                   <iframe style={{margin: "0 auto"}} width="560" height="315" src="https://www.youtube.com/embed/QTgZVbioTrA?si=PHpsE03Q8I6SqCDZ" title="YouTube video player" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerPolicy="strict-origin-when-cross-origin" allowFullScreen></iframe>
                 </div>
               </section>


### PR DESCRIPTION
## Summary
- Adds presentation link to the homepage

## Context
I believe the project requirements want us to attach both the demo _and_ the presentation slides. I've added the slides in case this is true.

## Screenshot

<img width="1509" alt="Screenshot 2024-11-03 at 9 18 07 AM" src="https://github.com/user-attachments/assets/4cde64eb-609b-4112-94fb-0bbb89872318">

